### PR TITLE
fix(whitelist): add pumatools.hu (legitimate Hungarian tool retailer)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -861,6 +861,16 @@ api.ipgeolocation.io
 #OPTIONAL: cdn.amplitude.com
 
 # ============================================================================
+# REPORTED FALSE POSITIVES
+# ============================================================================
+# Domains reported by users as incorrectly blocked by upstream sources.
+# Each entry should reference the GitHub issue it resolves.
+
+# Hungarian tool/hardware retailer ("Puma Tools, Csömör")
+# Flagged by Hagezi TIF; verified legitimate ecommerce site. (#19)
+pumatools.hu
+
+# ============================================================================
 # REGEX PATTERNS
 # ============================================================================
 # Google Push Notifications (all alternates)


### PR DESCRIPTION
## Summary

Whitelists `pumatools.hu`, reported as a false positive in #19.

## Investigation

- **Confirmed blocked**: `0.0.0.0 pumatools.hu` appears in `lists/malicious.txt` (and `comprehensive.txt` / `all_domains.txt` via dedup).
- **Upstream source**: Hagezi TIF (`||pumatools.hu^` in `tif.txt`). It is the only feed flagging the domain — checked against urlhaus, phishing.army, spam404, dandelion antimalware, curbengh phishing, jarelllama scams, hagezi fake, hagezi dyndns, and stalkerware-indicators. None of them list it.
- **Domain verification**: site returns HTTP 200 from `https://pumatools.hu` with title *"Puma Tools - Szerszám webáruház és üzlet Csömörön"* (Hungarian tool/hardware web shop and physical store in Csömör). Proper JSON-LD product structured data, OG tags, Cloudflare-fronted, Office 365 MX records. Consistent with a legitimate small-business ecommerce site, not a malware/phishing host.

## Change

- Adds a new `REPORTED FALSE POSITIVES` section to `whitelist.txt` with the convention that each entry references the issue it resolves. No prior section was a natural fit (existing sections are scoped to big services like Google/Microsoft/Apple).
- Adds `pumatools.hu` under that section with a one-line context comment and `#19` reference.

Whitelist effect will land on the next weekly optimizer run (Sunday midnight UTC) or on a manual workflow dispatch.

## Test plan

- [x] Verified domain is currently in `lists/malicious.txt`
- [x] Verified upstream source (Hagezi TIF)
- [x] Verified site legitimacy (HTTP 200, structured data, business identity)
- [ ] Optimizer regenerates `lists/*.txt` and `pumatools.hu` is no longer present

Closes #19