### PR TITLE
feat(blocklist): add gihub.com to malicious list

### DIFF
--- a/custom/malicious.txt
+++ b/custom/malicious.txt
@@ -2,3 +2,4 @@
 # Community-reported fake shops, scam sites, phishing domains
 # One domain per line — processed by the optimizer on weekly runs
 mbenergyholz.de
+gihub.com


### PR DESCRIPTION
## Summary
- Adds `gihub.com` to `custom/malicious.txt` — a typo-squatting domain for `github.com`
- Reporter (#21) documented it redirecting to fake antivirus warnings and fake DDoS-Guard "prove you're not a robot" pages (screenshots in the issue)

Domain will be picked up by the next weekly optimizer run.

Closes #21

## Test plan
- [x] Domain validated (single label typo of github.com, contains dot, no spaces/path)
- [x] Not already present in any `custom/*.txt` or `whitelist.txt`
- [x] Appended on a new line at the end of `custom/malicious.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)