### PR TITLE
fix(whitelist): add f005.backblazeb2.com for Backblaze B2

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -870,6 +870,13 @@ api.ipgeolocation.io
 # Flagged by Hagezi TIF; verified legitimate ecommerce site. (#19)
 pumatools.hu
 
+# Backblaze B2 download / native-API host for the us-east-005 storage cluster.
+# Shared infrastructure (serves /file/<bucket>/... for all tenants), not a
+# user-owned bucket; blocking it breaks B2 backups. Verified against Backblaze
+# IP space and live API behaviour. Abuse buckets keep their own
+# <bucket>.s3.us-east-005.backblazeb2.com hostnames and stay blocked. (#23)
+f005.backblazeb2.com
+
 # ============================================================================
 # REGEX PATTERNS
 # ============================================================================


### PR DESCRIPTION
## What

Whitelists `f005.backblazeb2.com` (added to the **REPORTED FALSE POSITIVES** section of `whitelist.txt`).

## Why

Reported in #23 — an upstream source listed it and it broke Backblaze B2 backups. Verified it's a **false positive**:

- Resolves into **Backblaze Inc** IP space (`149.137.136.16`, NetName `BACKB-7`).
- It's the shared **download / native-B2-API host** for the `us-east-005` cluster, **not** a user-owned bucket:
  - `GET /file/<bucket>/...` → `Bucket with such name does not exist` (bucket comes from the path; one host serves all tenants).
  - `GET /b2api/v3/...` → valid native B2 API error response.
  - Customer buckets live at `<bucket>.s3.<region>.backblazeb2.com`, never directly under the apex.

## Safety

Precise host entry, **not** a wildcard. The malicious per-bucket hostnames already in the list (e.g. `<bucket>.s3.us-east-005.backblazeb2.com`) are unaffected and remain blocked.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)