### PR TITLE
fix(whitelist): add ecsomag.hu for GLS eCsomag

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -877,6 +877,12 @@ pumatools.hu
 # <bucket>.s3.us-east-005.backblazeb2.com hostnames and stay blocked. (#23)
 f005.backblazeb2.com
 
+# GLS eCsomag — GLS Hungary's official parcel-sending portal.
+# Flagged only by the jarelllama scam list; verified legitimate: hosted on
+# GLS Hungary IP space (82.141.140.12) and GLS nameservers (ns1/ns2.gls-hungary.com),
+# registered 2015. Single-source upstream false positive. (#25)
+ecsomag.hu
+
 # ============================================================================
 # REGEX PATTERNS
 # ============================================================================


### PR DESCRIPTION
## What

Whitelists `ecsomag.hu` (added to the **REPORTED FALSE POSITIVES** section of `whitelist.txt`).

## Why

Reported in #25 — an upstream source listed it under `malicious.txt` and it broke the site for a user. Verified it's a **false positive**:

- IP `82.141.140.12` → whois **"GLS Hungary Kft."** (NetName `GLS`, HU).
- Nameservers `ns1.gls-hungary.com` / `ns2.gls-hungary.com` — GLS Hungary's own authoritative DNS.
- Registered **2015**; serves the live **"GLS eCsomag"** parcel-sending portal.
- Flagged by **only one** upstream feed — the [jarelllama scam list](https://github.com/jarelllama/Scam-Blocklist) (`||ecsomag.hu^`). Absent from phishing.army / Hagezi TIF / Hagezi fake. Single-source upstream false positive.

## Safety

A site hosted on GLS's own IP space and authoritative nameservers cannot be a third-party impersonator. Precise host entry, no wildcard.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)