### PR TITLE
docs(custom): reference originating issues and PRs for curated entries

### DIFF
--- a/custom/malicious.txt
+++ b/custom/malicious.txt
@@ -1,5 +1,9 @@
 # Custom Malicious Domains
 # Community-reported fake shops, scam sites, phishing domains
 # One domain per line — processed by the optimizer on weekly runs
+# Comment lines (#) are ignored by the optimizer; each entry references its issue + PR.
+
+# Fake shop (#17, PR #18)
 mbenergyholz.de
+# Typosquat of github.com — redirects to fake antivirus / DDoS-Guard scam pages (#21, PR #22)
 gihub.com

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -867,20 +867,20 @@ api.ipgeolocation.io
 # Each entry should reference the GitHub issue it resolves.
 
 # Hungarian tool/hardware retailer ("Puma Tools, Csömör")
-# Flagged by Hagezi TIF; verified legitimate ecommerce site. (#19)
+# Flagged by Hagezi TIF; verified legitimate ecommerce site. (#19, PR #20)
 pumatools.hu
 
 # Backblaze B2 download / native-API host for the us-east-005 storage cluster.
 # Shared infrastructure (serves /file/<bucket>/... for all tenants), not a
 # user-owned bucket; blocking it breaks B2 backups. Verified against Backblaze
 # IP space and live API behaviour. Abuse buckets keep their own
-# <bucket>.s3.us-east-005.backblazeb2.com hostnames and stay blocked. (#23)
+# <bucket>.s3.us-east-005.backblazeb2.com hostnames and stay blocked. (#23, PR #24)
 f005.backblazeb2.com
 
 # GLS eCsomag — GLS Hungary's official parcel-sending portal.
 # Flagged only by the jarelllama scam list; verified legitimate: hosted on
 # GLS Hungary IP space (82.141.140.12) and GLS nameservers (ns1/ns2.gls-hungary.com),
-# registered 2015. Single-source upstream false positive. (#25)
+# registered 2015. Single-source upstream false positive. (#25, PR #26)
 ecsomag.hu
 
 # ============================================================================


### PR DESCRIPTION
Adds inline issue + PR references to every community-curated entry so each one's provenance is visible at a glance.

## `custom/malicious.txt`
| Domain | Issue | PR |
|---|---|---|
| `mbenergyholz.de` | #17 | #18 |
| `gihub.com` | #21 | #22 |

## `whitelist.txt` (Reported False Positives)
| Domain | Issue | PR |
|---|---|---|
| `pumatools.hu` | #19 | #20 |
| `f005.backblazeb2.com` | #23 | #24 |
| `ecsomag.hu` | #25 | #26 |

## Notes

- Comment lines (`#`) are ignored by the optimizer, so this is metadata-only — no change to which domains are blocked/allowed.
- Only entries that have **both** an issue and a merged PR are annotated. Older whitelist entries (the VPN/DNS/service sections) predate the PR-based workflow and were committed directly, so they have no PR to reference.