### PR TITLE
fix(whitelist): add serverelite.hu for ServerElite webshop

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -883,6 +883,12 @@ f005.backblazeb2.com
 # registered 2015. Single-source upstream false positive. (#25, PR #26)
 ecsomag.hu
 
+# ServerElite (MARAELITE Kft) — established Hungarian refurbished enterprise-server shop.
+# Flagged only by the jarelllama scam list; verified legitimate: domain registered 2017,
+# Microsoft 365 business email, real OpenCart storefront, and listed by FT/Statista among
+# Europe's fastest-growing companies (2024). Single-source upstream false positive. (#29)
+serverelite.hu
+
 # ============================================================================
 # REGEX PATTERNS
 # ============================================================================

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -886,7 +886,7 @@ ecsomag.hu
 # ServerElite (MARAELITE Kft) — established Hungarian refurbished enterprise-server shop.
 # Flagged only by the jarelllama scam list; verified legitimate: domain registered 2017,
 # Microsoft 365 business email, real OpenCart storefront, and listed by FT/Statista among
-# Europe's fastest-growing companies (2024). Single-source upstream false positive. (#29)
+# Europe's fastest-growing companies (2024). Single-source upstream false positive. (#29, PR #30)
 serverelite.hu
 
 # ============================================================================


### PR DESCRIPTION
## What

Whitelists `serverelite.hu` (added to the **REPORTED FALSE POSITIVES** section of `whitelist.txt`).

## Why

Reported in #29 — an upstream source listed it under `malicious.txt` and it broke the site for a user. A webshop in a scam feed warrants scrutiny, so this was checked carefully and is a **false positive**:

- **ServerElite** (operator **MARAELITE Kft**) — established Hungarian retailer of refurbished enterprise servers (Dell/HPE).
- Domain registered **2017**, Microsoft 365 business email, real OpenCart storefront with full company identity (Budapest address, phone, Dell Gold Partner, ISO 9001/14001/27001), card payments.
- Independently corroborated: named by **Financial Times / Statista** among Europe's fastest-growing companies (2024).
- Flagged by **only one** upstream feed — the [jarelllama scam list](https://github.com/jarelllama/Scam-Blocklist) (`||serverelite.hu^`). Absent from phishing.army / Hagezi TIF/fake / Spam404. Same single-source feed that false-positived #25.

## Safety

Precise host entry, no wildcard. Aged domain + business M365 mail + verifiable company identity + FT/Statista listing collectively rule out a fake shop.

Closes #29