### PR TITLE
feat(blocklist): add netflxi.com typosquat chain to malicious list

### DIFF
--- a/custom/malicious.txt
+++ b/custom/malicious.txt
@@ -7,3 +7,9 @@
 mbenergyholz.de
 # Typosquat of github.com — redirects to fake antivirus / DDoS-Guard scam pages (#21, PR #22)
 gihub.com
+# Netflix typosquat ("netflxi" ↔ "netflix") parked on Above.com; cloaks scanners and
+# redirects real browsers through a malicious chain to yexyed.com / novugs.com. yexyed
+# shares netflxi's Above.com redirect /24; both targets are 2026 throwaway domains. (#31, PR #32)
+netflxi.com
+yexyed.com
+novugs.com


### PR DESCRIPTION
## What

Adds three domains to `custom/malicious.txt`: `netflxi.com`, `yexyed.com`, `novugs.com`.

## Why

A Netflix typosquat and its malicious redirect chain, reported in #31.

- **`netflxi.com`** — typosquat of `netflix.com` (`xi`↔`ix`), parked on **Above.com** redirect infra (`*.ABOVEDOMAINS.COM`, IP `103.224.182.245`). **Cloaks** — serves `404` to `curl`/scanners but redirects real browsers. Not Netflix-owned.
- **`yexyed.com`** — registered **2026-04-02**, on Above.com `RDRCENTRAL.COM` ("redirect central") nameservers, IP `103.224.182.220` — same Above.com `/24` as netflxi.com, tying it to the chain.
- **`novugs.com`** — registered **2026-05-02**, Namecheap/Hetzner throwaway.

## Notes

The repo guideline is normally one domain per PR; these three are grouped because they're a single threat cluster (the typosquat plus the two redirect endpoints it funnels to).

Closes #31