### PR TITLE
fix(whitelist): allow AdsPower domains (anti-detect browser)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -920,6 +920,14 @@ serverelite.hu
 # Microsoft telemetry subdomains (specific ones needed for functionality)
 /^v[0-9]+\.events\.data\.microsoft\.com$/
 
+# AdsPower — legitimate anti-detect / multi-account browser service. Hagezi Pro lists
+# its app/telemetry domains (apex + subdomains incl. sentry/logger/activity), which
+# breaks the app. Covers apex + all subdomains, incl. the Russian domain adspower-ru.com.
+# Does NOT match adspowertrack.digital, which stays blocked. (#33)
+/(\.|^)adspower\.com$/
+/(\.|^)adspower\.net$/
+/(\.|^)adspower-ru\.com$/
+
 # ============================================================================
 # WILDCARD PATTERNS
 # ============================================================================

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -923,7 +923,7 @@ serverelite.hu
 # AdsPower — legitimate anti-detect / multi-account browser service. Hagezi Pro lists
 # its app/telemetry domains (apex + subdomains incl. sentry/logger/activity), which
 # breaks the app. Covers apex + all subdomains, incl. the Russian domain adspower-ru.com.
-# Does NOT match adspowertrack.digital, which stays blocked. (#33)
+# Does NOT match adspowertrack.digital, which stays blocked. (#33, PR #34)
 /(\.|^)adspower\.com$/
 /(\.|^)adspower\.net$/
 /(\.|^)adspower-ru\.com$/


### PR DESCRIPTION
## What

Adds regex allowlist entries for **AdsPower** (apex + all subdomains):

```
/(\.|^)adspower\.com$/
/(\.|^)adspower\.net$/
/(\.|^)adspower-ru\.com$/
```

## Why

Reported in #33. AdsPower is a legitimate anti-detect / multi-account browser service. **Hagezi Pro** lists its app/telemetry domains (apex + ~13 subdomains incl. `sentry`/`logger`/`activity`/`api`/`download`), which breaks the desktop app (login, sync, updates, license checks) on networks using `comprehensive`/`all_domains`. OISD does not list them.

- `adspower.com` (1995, GoDaddy) and `adspower.net` (2020, Alibaba) resolve to AdsPower's anycast IPs — the genuine service.
- `adspower-ru.com` is AdsPower's Russian-region domain (legitimate), currently caught by `malicious.txt`.

## Scope / safety

- Regex covers apex + every current and future subdomain in three lines (same idiom the list already uses for reddit/twitter).
- Does **not** match `adspowertrack.digital` (a distinct base domain), which stays blocked.

Closes #33