### PR TITLE
feat(custom): enable ABP wildcard entries for custom lists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ When running as a GitHub Actions agent processing issues, follow these procedure
 4. Validate the domain: must contain at least one dot, no spaces, no path components
 5. Check the domain is not already in any `custom/*.txt` file or `whitelist.txt`
 6. Append the domain on a new line at the end of the appropriate `custom/<category>.txt`
+   - To block a domain **and all its subdomains** (e.g. a tracking SDK that uses many hashed subdomains), append `||<domain>^` instead of the bare domain. A plain `<domain>` blocks only the exact host. Reporter requests written as `*.<domain>` map to `||<domain>^`.
 7. Create a PR:
    - Title: `feat(blocklist): add <domain> to <category> list`
    - Body: explain what was added, why, and include `Closes #<issue_number>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ Use the **Bug Report** template with as much detail as possible. Steps to reprod
 ## How It Works
 
 - `custom/<category>.txt` files hold community-reported domains to block (one domain per line)
+- Custom lists support wildcard blocking: a line `||example.com^` (or the shorthand `*.example.com`) blocks `example.com` **and all its subdomains**, while a plain `example.com` blocks only that exact host. Wildcards apply to `custom/*.txt` only.
 - `whitelist.txt` holds domains that should not be blocked (organised by service/section)
 - `blocklists.conf` holds URLs to upstream blocklist sources (`url|name|category` format)
 - The optimizer binary runs weekly, downloads all sources (including the custom lists via raw GitHub URL), and produces the deduplicated output in `lists/`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 2. Add the raw URL for your chosen list(s)
 3. Run `pihole -g` to update
 
+> The lists may include ABP-style entries (`||domain^`) that block a domain and all its subdomains. These require Pi-hole Core ≥ 5.16 / FTL ≥ 5.22 (released 2023; standard on current installs). Note that `pihole -q` won't enumerate the individual subdomains covered by an ABP entry.
+
 ## Report a Domain
 
 Found a domain that should be blocked or a false positive? Open an issue using one of the templates:

--- a/blocklists.conf
+++ b/blocklists.conf
@@ -61,11 +61,11 @@ https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt
 # ============================================================================
 # CUSTOM DOMAIN LISTS (Community-reported)
 # ============================================================================
-https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/malicious.txt|custom_malicious|malicious
-https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/advertising.txt|custom_advertising|advertising
-https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/tracking.txt|custom_tracking|tracking
-https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/suspicious.txt|custom_suspicious|suspicious
-https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/nsfw.txt|custom_nsfw|nsfw
+https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/malicious.txt|custom_malicious|malicious|abp
+https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/advertising.txt|custom_advertising|advertising|abp
+https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/tracking.txt|custom_tracking|tracking|abp
+https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/suspicious.txt|custom_suspicious|suspicious|abp
+https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/custom/nsfw.txt|custom_nsfw|nsfw|abp
 
 # ============================================================================
 # NSFW BLOCKLISTS


### PR DESCRIPTION
Flags the five `custom_*` sources in `blocklists.conf` with `|abp` so curated entries written as `||domain^` (or the shorthand `*.domain`) block a domain **and all its subdomains**, instead of being flattened to an exact host.

- `blocklists.conf` — `|abp` on `custom_malicious` / `custom_advertising` / `custom_tracking` / `custom_suspicious` / `custom_nsfw`.
- `CONTRIBUTING.md` + `CLAUDE.md` — document the `||domain^` / `*.domain` authoring syntax (custom lists only, apex + subdomains).
- `README.md` — note ABP entries require Pi-hole Core ≥ 5.16.

**Requires** optimizer **v3.1.0** (zachlagden/Pi-hole-Blocklist-Optimizer#3), which adds the per-source `abp` flag. The old v3.0.0 binary skips 4-field conf lines — do not merge until v3.1.0 is the published release. Enables the wildcard form for the Vungle/AppsFlyer block requests (#35, #38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)