### PR TITLE
feat(blocklist): add aditude.prebid-server.com to advertising list

### DIFF
--- a/custom/advertising.txt
+++ b/custom/advertising.txt
@@ -1,3 +1,5 @@
 # Custom Advertising Domains
 # Community-reported ad-serving domains
 # One domain per line — processed by the optimizer on weekly runs
+# Aditude Prebid Server — server-side header-bidding ad endpoint (#36, PR #41)
+aditude.prebid-server.com


### PR DESCRIPTION
Adds `aditude.prebid-server.com` to `custom/advertising.txt`.

Reported in #36 — Aditude's managed **Prebid Server** is a server-side header-bidding ad endpoint (programmatic ad auctions). Pure ad-serving infrastructure; appropriate to block. Single exact host, no wildcard needed.

Closes #36