### PR TITLE
feat(blocklist): add ads.vungle.com (+subdomains) to advertising list

### DIFF
--- a/custom/advertising.txt
+++ b/custom/advertising.txt
@@ -3,3 +3,5 @@
 # One domain per line — processed by the optimizer on weekly runs
 # Aditude Prebid Server — server-side header-bidding ad endpoint (#36, PR #41)
 aditude.prebid-server.com
+# Vungle (Liftoff) mobile ad-serving network — apex + all subdomains (#35, PR #42)
+||ads.vungle.com^


### PR DESCRIPTION
Adds `||ads.vungle.com^` to `custom/advertising.txt`.

Reported in #35 — Vungle (now **Liftoff**) is a mobile ad-serving network; `ads.vungle.com` and its subdomains (`rtb`, `adx`, `events`, …) are pure ad infrastructure. Uses the ABP wildcard form `||ads.vungle.com^` to cover the apex **and all subdomains** in one line.

Requires the `abp` flag on `custom_advertising` (#40) and optimizer v3.1.0; until both are live the entry blocks the exact apex only.

Closes #35