### PR TITLE
feat(blocklist): add appsflyersdk.com (+subdomains) to tracking list

### DIFF
--- a/custom/tracking.txt
+++ b/custom/tracking.txt
@@ -1,3 +1,5 @@
 # Custom Tracking Domains
 # Community-reported tracking and telemetry domains
 # One domain per line — processed by the optimizer on weekly runs
+# AppsFlyer mobile attribution / tracking SDK — apex + all subdomains (#38, PR #43)
+||appsflyersdk.com^


### PR DESCRIPTION
Adds `||appsflyersdk.com^` to `custom/tracking.txt`.

Reported in #38 — AppsFlyer is a mobile attribution / tracking SDK; apps phone home to thousands of per-app hashed subdomains under `appsflyersdk.com` (`*.cdn-settings`, `*.launches`, …). The ABP form `||appsflyersdk.com^` covers the apex **and all subdomains** in one line — the right tool here, since enumerating the hashed hosts is impractical. Correct category: tracking.

Requires the `abp` flag on `custom_tracking` (#40) and optimizer v3.1.0; until both are live the entry blocks the exact apex only.

Closes #38