### PR TITLE
feat(lists): publish ABP subdomain-blocking nsfw_abp.txt

### DIFF
--- a/.github/workflows/update-blocklists.yml
+++ b/.github/workflows/update-blocklists.yml
@@ -36,6 +36,7 @@ jobs:
           ./pihole-optimizer \
             -t 8 \
             --whitelist-report \
+            --abp-lists nsfw \
             --prod-dir pihole_blocklists_prod
 
           # Verify output
@@ -149,6 +150,7 @@ jobs:
           /\[suspicious\.txt\]/ { gsub(/[0-9,]+ \|$/, sus " |") }
           /\[comprehensive\.txt\]/ { gsub(/[0-9,]+ \|$/, comp " |") }
           /\[nsfw\.txt\]/ { gsub(/[0-9,]+ \|$/, nsfw " |") }
+          /\[nsfw_abp\.txt\]/ { gsub(/[0-9,]+ \|$/, nsfw " |") }
           { print }
           ' README.md > README.md.tmp && mv README.md.tmp README.md
 
@@ -159,7 +161,7 @@ jobs:
         run: |
           mkdir -p lists
 
-          FILES=("all_domains.txt" "advertising.txt" "tracking.txt" "malicious.txt" "suspicious.txt" "comprehensive.txt" "nsfw.txt")
+          FILES=("all_domains.txt" "advertising.txt" "tracking.txt" "malicious.txt" "suspicious.txt" "comprehensive.txt" "nsfw.txt" "nsfw_abp.txt")
           CHANGES_DETECTED=false
           CHANGED_FILES=""
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 
 </div>
 
+> [!NOTE]
+> **New — `nsfw_abp.txt`, a subdomain-blocking NSFW list.** An ABP-format version of `nsfw.txt` that blocks adult domains **and all their subdomains** (e.g. `cdn.example.com` as well as `example.com`) for more complete filtering. Requires Pi-hole Core ≥ 5.16 / FTL ≥ 5.22. See [Available Lists](#available-lists).
+
 > **Looking for more features?** Check out [Zach's Lists](https://lists.zachlagden.uk) — a full-featured blocklist platform with custom source selection, smart whitelisting, and multiple output formats.
 
 ---
@@ -25,8 +28,9 @@
 | **[suspicious.txt](https://media.githubusercontent.com/media/zachlagden/Pi-hole-Optimized-Blocklists/main/lists/suspicious.txt)** | Potentially unwanted | 60,349 |
 | **[comprehensive.txt](https://media.githubusercontent.com/media/zachlagden/Pi-hole-Optimized-Blocklists/main/lists/comprehensive.txt)** | Curated multi-category | 888,685 |
 | **[nsfw.txt](https://media.githubusercontent.com/media/zachlagden/Pi-hole-Optimized-Blocklists/main/lists/nsfw.txt)** | Adult content (separate) | 339,662 |
+| **[nsfw_abp.txt](https://media.githubusercontent.com/media/zachlagden/Pi-hole-Optimized-Blocklists/main/lists/nsfw_abp.txt)** | Adult content — ABP format, blocks subdomains too | 339,662 |
 
-> **Note:** `nsfw.txt` is **not** included in `all_domains.txt` because it blocks legitimate adult sites. Add it separately if you want NSFW blocking.
+> **Note:** `nsfw.txt` is **not** included in `all_domains.txt` because it blocks legitimate adult sites. Add it separately if you want NSFW blocking. `nsfw_abp.txt` is the same domains in ABP form (`||domain^`) so subdomains are blocked too — use it instead of `nsfw.txt` for more thorough filtering (needs Pi-hole Core ≥ 5.16).
 
 **Last updated**: June 28, 2026
 


### PR DESCRIPTION
Adds an opt-in **`nsfw_abp.txt`** — the same NSFW domains as `nsfw.txt` but in ABP form (`||domain^`), so it blocks adult domains **and all their subdomains**. Closes #44.

- `update-blocklists.yml`: pass `--abp-lists nsfw` (optimizer **v3.2.0**), copy `nsfw_abp.txt` into `lists/`, keep its count synced.
- `README.md`: top notice + Available Lists row.

NSFW is the right (and only) candidate for now — its entries are dedicated adult domains, so ABP-wrapping is safe; the other lists already enumerate subdomains upstream and contain hosts where blanket wrapping could over-block.

Generated by the next run of the update workflow.