### PR TITLE
fix(whitelist): add norwex.com for Norwex (NSFW false positive)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,5 +1,5 @@
 # Zach's Lists - Default Whitelist
-# Last Updated: 06/07/2026 - 09:04 UTC - Allowlisted commbank.com.au (Commonwealth Bank of Australia false positive, jarelllama feed)
+# Last Updated: 08/07/2026 - 10:42 UTC - Allowlisted norwex.com (cleaning-products retailer miscategorised by OISD NSFW list)
 
 # ============================================================================
 # GOOGLE SERVICES
@@ -896,6 +896,12 @@ serverelite.hu
 # government finance.gov.au register. Same single-source feed that false-positived #25/#29.
 # Subdomain matching also covers www/netbank. (#46, PR #47)
 commbank.com.au
+
+# Norwex — legitimate eco-friendly cleaning-products retailer (microfibre cloths, direct
+# sales, est. 1994). Miscategorised by the OISD NSFW list (||norwex.com^); the site is a
+# live storefront (norwex.com -> www.norwex.com, HTTP 200) with no adult content. Single-
+# source NSFW false positive; whitelisting removes it from nsfw.txt and nsfw_abp.txt. (#48, PR #49)
+norwex.com
 
 # ============================================================================
 # REGEX PATTERNS


### PR DESCRIPTION
Whitelists `norwex.com` (added to the **REPORTED FALSE POSITIVES** section).

Reported in #48 — blocked by `nsfw.txt` and it broke the user's shopping. Verified **false positive**:

- **Norwex** is a legitimate eco-friendly cleaning-products retailer (microfibre cloths, direct sales, est. 1994). `norwex.com` is its official storefront — resolves to `www.norwex.com` and returns HTTP 200, no adult content.
- **Single source:** miscategorised by the **OISD NSFW** list (`||norwex.com^`), the only NSFW feed we use. Not in our curated `custom/*`.

## Safety

Precise host entry (subdomain matching also covers `www`). Whitelisting removes it from both `nsfw.txt` and `nsfw_abp.txt`.

Closes #48