### PR TITLE
fix(whitelist): add taxpolicy.org.uk for Tax Policy Associates

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,5 +1,5 @@
 # Zach's Lists - Default Whitelist
-# Last Updated: 08/07/2026 - 10:42 UTC - Allowlisted norwex.com (cleaning-products retailer miscategorised by OISD NSFW list)
+# Last Updated: 19/07/2026 - 16:03 UTC - Allowlisted taxpolicy.org.uk (Tax Policy Associates; jarelllama/ScamMinder false positive)
 
 # ============================================================================
 # GOOGLE SERVICES
@@ -902,6 +902,14 @@ commbank.com.au
 # live storefront (norwex.com -> www.norwex.com, HTTP 200) with no adult content. Single-
 # source NSFW false positive; whitelisting removes it from nsfw.txt and nsfw_abp.txt. (#48, PR #49)
 norwex.com
+
+# Tax Policy Associates Ltd — UK non-profit tax-policy think tank and investigative journalism
+# (live site, HTTP 200, "the independent tax think tank"). Flagged only by the jarelllama scam
+# list (||taxpolicy.org.uk^), which traces upstream to ScamMinder — now rating the domain 100/100,
+# so the original signal no longer holds. Absent from phishing.army, Hagezi TIF/fake, curbengh and
+# Spam404. Reported by the domain owner. Fourth single-source FP from this feed (cf. #25, #29, #46).
+# Unrelated lookalikes such as taxpolicyapi.xyz are separate domains and stay blocked. (#50, PR #51)
+taxpolicy.org.uk
 
 # ============================================================================
 # REGEX PATTERNS


### PR DESCRIPTION
Whitelists `taxpolicy.org.uk` (added to the **REPORTED FALSE POSITIVES** section).

Reported in #50 **by the domain owner** — blocked via `malicious.txt`, so it was active by default for anyone on the combined lists. Verified **false positive**:

- **Tax Policy Associates Ltd** is a UK non-profit tax-policy think tank publishing free analysis and investigative journalism. The site is live (HTTP 200, *"the independent tax think tank"*) with no ads, tracking, malware or scam activity.
- **Single source:** flagged **only** by the [jarelllama Scam-Blocklist](https://github.com/jarelllama/Scam-Blocklist) (`||taxpolicy.org.uk^`), which traces upstream to ScamMinder — now rating the domain **100/100**, so the signal that originally flagged it no longer holds. Absent from phishing.army, Hagezi TIF/fake, curbengh phishing and Spam404.
- This is the **fourth** single-source false positive from this same feed (cf. #25, #29, #46).

## Safety

Precise host entry (subdomain matching also covers `www`). Unrelated lookalikes such as `taxpolicyapi.xyz` are separate registrable domains and **stay blocked**. The whitelist entry is durable — it keeps the domain excluded even if a cached upstream copy lingers.

Closes #50