### PR TITLE
fix(whitelist): add genspark.ai for Genspark (MainFunc AI platform)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,5 +1,5 @@
 # Zach's Lists - Default Whitelist
-# Last Updated: 19/07/2026 - 16:03 UTC - Allowlisted taxpolicy.org.uk (Tax Policy Associates; jarelllama/ScamMinder false positive)
+# Last Updated: 22/07/2026 - 13:57 UTC - Allowlisted genspark.ai (Genspark/MainFunc AI platform; phishing.army false positive)
 
 # ============================================================================
 # GOOGLE SERVICES
@@ -910,6 +910,14 @@ norwex.com
 # Spam404. Reported by the domain owner. Fourth single-source FP from this feed (cf. #25, #29, #46).
 # Unrelated lookalikes such as taxpolicyapi.xyz are separate domains and stay blocked. (#50, PR #51)
 taxpolicy.org.uk
+
+# Genspark — AI search/agent platform operated by MainFunc, Inc. (Palo Alto; mainfunc.ai).
+# genspark.ai + www.genspark.ai were flagged only by phishing.army (extended) — absent from
+# jarelllama, Hagezi TIF/fake, curbengh, Spam404, URLhaus, Dandelion — likely collateral from
+# abuse of Genspark's SEPARATE user-content domain gensparkspace.com, which is deliberately
+# NOT whitelisted and stays blocked (reporter explicitly scoped it out). Subdomain matching
+# covers www. Single-source upstream false positive. (#52, PR #53)
+genspark.ai
 
 # ============================================================================
 # REGEX PATTERNS


### PR DESCRIPTION
Whitelists `genspark.ai` (added to the **REPORTED FALSE POSITIVES** section; subdomain matching covers `www.genspark.ai`).

Reported in #52 — both hosts were in `malicious.txt`, blocking the official Genspark site/app. Verified **false positive**:

- **Genspark** is a legitimate AI search/agent platform operated by **MainFunc, Inc.** (Palo Alto; see [mainfunc.ai](https://mainfunc.ai/)) — a well-known, actively used commercial service.
- **Single source:** flagged **only** by **phishing.army (extended)** — absent from jarelllama, Hagezi TIF/fake, curbengh phishing, Spam404, URLhaus, Dandelion and hagezi dyndns. Most plausibly collateral from phishing abuse of Genspark's *separate* user-content domain.

## Safety

- Precise entry: only `genspark.ai` (+ its subdomains, i.e. `www`) is whitelisted — the only two `genspark.ai` hosts in our lists.
- `gensparkspace.com` (user-generated-content hosting, a different root domain and a known abuse surface) is deliberately **NOT** whitelisted — its entries (`public.`/`vjnkfvgl.gensparkspace.com`) stay blocked, exactly as the reporter requested.

Closes #52