### PR TITLE
fix(whitelist): add chat.z.ai for Z.ai (Zhipu GLM chat frontend)

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,5 +1,5 @@
 # Zach's Lists - Default Whitelist
-# Last Updated: 22/07/2026 - 13:57 UTC - Allowlisted genspark.ai (Genspark/MainFunc AI platform; phishing.army false positive)
+# Last Updated: 27/07/2026 - 12:21 UTC - Allowlisted chat.z.ai (Z.ai/Zhipu GLM chat frontend; phishing.army false positive)
 
 # ============================================================================
 # GOOGLE SERVICES
@@ -918,6 +918,13 @@ taxpolicy.org.uk
 # NOT whitelisted and stays blocked (reporter explicitly scoped it out). Subdomain matching
 # covers www. Single-source upstream false positive. (#52, PR #53)
 genspark.ai
+
+# Z.ai (Zhipu AI) — chat.z.ai is the official GLM chat/agent frontend (live, HTTP 200,
+# "Z.ai - Advanced AI Chatbot & Agent powered by GLM"). Flagged only by phishing.army
+# (extended) — absent from jarelllama, Hagezi TIF/fake, curbengh, Spam404, URLhaus,
+# Dandelion. Only z.ai host in our lists (apex not blocked). Single-source FP; second
+# from phishing.army after genspark.ai (#52). (#54, PR #55)
+chat.z.ai
 
 # ============================================================================
 # REGEX PATTERNS


### PR DESCRIPTION
Whitelists `chat.z.ai` (added to the **REPORTED FALSE POSITIVES** section).

Reported in #54 — blocked by `malicious.txt`, making the site unreachable. Verified **false positive**:

- **Z.ai** (Zhipu AI) — `chat.z.ai` is the official GLM chat/agent frontend. Live: HTTP 200, *"Z.ai - Advanced AI Chatbot & Agent powered by GLM-5.2"*.
- **Single source:** flagged **only** by **phishing.army (extended)** — absent from the jarelllama scam list, Hagezi TIF/fake, curbengh phishing, Spam404, URLhaus, Dandelion and hagezi dyndns.
- It's the **only** `z.ai` host in our lists (the apex isn't blocked), so no wider change is needed.

## Safety

Precise host entry (subdomain matching covers any `*.chat.z.ai`). Second single-source false positive from phishing.army in a row (after genspark.ai, #52).

Closes #54