### PR TITLE
feat(blocklist): add scientificfor.com to advertising list

### DIFF
--- a/custom/advertising.txt
+++ b/custom/advertising.txt
@@ -5,3 +5,8 @@
 aditude.prebid-server.com
 # Vungle (Liftoff) mobile ad-serving network — apex + all subdomains (#35, PR #42)
 ||ads.vungle.com^
+# scientificfor.com — ad-serving/redirect domain caught in a HuffPost banner ad (inspected element).
+# Young throwaway domain (registered 2026-02-18, GoDaddy/Cloudflare), 404 at apex — no real site.
+# Already flagged by hagezi Pro + oisd Big (so live in comprehensive/all_domains); this extends the
+# block to the advertising category list. Apex + all subdomains (#61, PR #64)
+||scientificfor.com^


### PR DESCRIPTION
## What

Adds `||scientificfor.com^` to `custom/advertising.txt`.

## Why

Reported (#61) serving a **banner ad on HuffPost**, confirmed by the reporter via inspected element. Verification supports an ad-infra block:

- **Young throwaway domain** — registered **2026-02-18** (GoDaddy, Cloudflare-fronted).
- **No real site** — apex returns **404**, consistent with ad-serving/redirect infrastructure rather than a destination brand.
- **Corroborated** — already flagged by **hagezi Pro** and **oisd Big**, so it's live in our `comprehensive.txt` and `all_domains.txt`. This PR extends the block to the standalone `advertising.txt` (where it was missing), matching the reporter's category.

Entered in ABP form (`||domain^`) to cover the apex and any subdomains.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)