### PR TITLE
feat(blocklist): add fake-RingGo phishing cluster to malicious list

### DIFF
--- a/custom/malicious.txt
+++ b/custom/malicious.txt
@@ -13,3 +13,19 @@ gihub.com
 netflxi.com
 yexyed.com
 novugs.com
+# Fake RingGo (UK parking payments) phishing cluster — harvests logins + payment-card details via
+# fake "/uk/" checkout pages. Two credential-capture kit hosts (RingGo typosquats) plus redirectors
+# that funnel victims into them; confirmed live redirect chains at time of report (maintainer report):
+#   my-ringgo.com     — kit host, typosquat, registered 2026-08-01, Cloudflare, live /uk/index.php
+#   ringgo-portal.ink — second kit host, typosquat (.ink), /uk/?ref= landing
+#   baudirdeinregal.de — redirector → my-ringgo.com/uk/index.php?id=…
+#   halaalstyle.com   — compromised aged site (2018) redirecting → ringgo-portal.ink/uk/?ref=… (review if remediated)
+#   awadio.pl         — related redirector/staging node (Cloudflare)
+#   lamanucure.de     — phishing sender infrastructure (mail@lamanucure.de)
+# Apex + all subdomains (ABP). (maintainer report, PR #67)
+||my-ringgo.com^
+||ringgo-portal.ink^
+||baudirdeinregal.de^
+||halaalstyle.com^
+||awadio.pl^
+||lamanucure.de^


### PR DESCRIPTION
## What

Adds six domains to `custom/malicious.txt` (ABP form) — a **fake RingGo (UK parking-payment) phishing cluster** that harvests logins and payment-card details.

## The cluster

Two credential-capture kit hosts (RingGo typosquats serving fake `/uk/` checkout pages) plus the redirectors funnelling victims into them. Redirect chains were verified live at time of report:

| Domain | Role | Notes |
|--------|------|-------|
| `my-ringgo.com` | Kit host | Typosquat, registered **2026-08-01**, Cloudflare, live `/uk/index.php` |
| `ringgo-portal.ink` | Kit host | Typosquat (`.ink`), `/uk/?ref=` landing |
| `baudirdeinregal.de` | Redirector | → `my-ringgo.com/uk/index.php?id=…` |
| `halaalstyle.com` | Redirector | **Compromised** aged site (2018) → `ringgo-portal.ink/uk/?ref=…` — review if remediated |
| `awadio.pl` | Redirector / staging | Cloudflare-fronted |
| `lamanucure.de` | Sender infra | From `mail@lamanucure.de` |

Entered as `||domain^` so each apex and all subdomains are blocked.

> Note: `halaalstyle.com` is an aged, likely-legitimate domain that has been compromised and is actively redirecting into the phishing kit. It's blocked while malicious; it can be reviewed for removal once the compromise is remediated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)