### PR TITLE
fix(sources): remove jarelllama scam list from blocklists.conf

### DIFF
--- a/blocklists.conf
+++ b/blocklists.conf
@@ -1,5 +1,5 @@
 # Zach's Lists - Default Block List
-# Last Updated: 13/01/26 - 02:07 - Removed hagezi_bypass to fix VPN/DNS false positives
+# Last Updated: 17/08/26 - Removed jarelllama_scams — 6 confirmed single-source false positives (see #66)
 
 # ============================================================================
 # COMPREHENSIVE BLOCKLISTS
@@ -45,7 +45,6 @@ https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.huaw
 https://urlhaus.abuse.ch/downloads/hostfile/|urlhaus|malicious
 https://phishing.army/download/phishing_army_blocklist_extended.txt|phishing_army|malicious
 https://raw.githubusercontent.com/AssoEchap/stalkerware-indicators/master/generated/hosts|stalkerware_indicators|malicious
-https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/adblock/scams.txt|jarelllama_scams|malicious
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/fake.txt|hagezi_fake|malicious
 https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt|dandelion_antimalware|malicious
 https://malware-filter.gitlab.io/malware-filter/phishing-filter-hosts.txt|curbengh_phishing|malicious


### PR DESCRIPTION
## What

Removes the `jarelllama_scams` source from `blocklists.conf`.

## Why

The jarelllama Scam-Blocklist has produced **six confirmed single-source false positives**, each a legitimate site caught by this feed alone and absent from every other source we pull (phishing.army, HaGeZi TIF/fake, curbengh, Spam404, URLhaus, Dandelion):

| Issue | Domain |
|-------|--------|
| #25 | `ecsomag.hu` |
| #29 | `serverelite.hu` |
| #46 | `commbank.com.au` |
| #50 | `taxpolicy.org.uk` |
| #59 | `rei.com` |
| #66 | `thefrenchghosty.me` |

The #66 report (from the affected domain's owner) documented the root cause: the feed **indiscriminately blocks newly-registered domains**, with external corroboration that others were hit (blocklistproject/Lists#2152).

Given the sustained false-positive rate — and that no unique true-positive coverage has been observed from it that the reputable feeds don't already provide — the feed is removed at the source rather than worked around with further per-domain whitelisting.

## Notes

- Active sources: 35 → 34.
- Existing `whitelist.txt` entries for the six affected domains are **retained** as durable safeguards (in case another feed flags them in future).
- Takes effect on the next weekly rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)