### PR TITLE
fix(sources): repair 8 dead hagezi feed URLs (repo restructure)

### DIFF
--- a/blocklists.conf
+++ b/blocklists.conf
@@ -1,10 +1,10 @@
 # Zach's Lists - Default Block List
-# Last Updated: 17/08/26 - Removed jarelllama_scams — 6 confirmed single-source false positives (see #66)
+# Last Updated: 18/08/26 - Fixed 8 dead hagezi feed URLs (repo moved hosts/ + domains/ → adblock/)
 
 # ============================================================================
 # COMPREHENSIVE BLOCKLISTS
 # ============================================================================
-https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/hosts/pro.txt|hagezi_pro|comprehensive
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/pro.txt|hagezi_pro|comprehensive
 https://big.oisd.nl|oisd_big|comprehensive
 
 # ============================================================================
@@ -16,8 +16,8 @@ https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/tif.txt|hagezi_
 # STREAMING DEVICES & SMART TV
 # ============================================================================
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt|perflyst_smarttv|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.roku.txt|hagezi_roku|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.lgwebos.txt|hagezi_lg|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.roku.txt|hagezi_roku|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.lgwebos.txt|hagezi_lg|tracking
 
 # ============================================================================
 # ADVERTISING BLOCKLISTS
@@ -33,11 +33,11 @@ https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/popupads.txt|ha
 https://hostfiles.frogeye.fr/firstparty-trackers-hosts.txt|frogeye_firstparty|tracking
 https://raw.githubusercontent.com/nextdns/cname-cloaking-blocklist/master/domains|nextdns_cname|tracking
 https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/android-tracking.txt|perflyst_android|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.winoffice.txt|hagezi_windows|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.apple.txt|hagezi_apple|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.samsung.txt|hagezi_samsung_mobile|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.xiaomi.txt|hagezi_xiaomi|tracking
-https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/native.huawei.txt|hagezi_huawei|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.winoffice.txt|hagezi_windows|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.apple.txt|hagezi_apple|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.samsung.txt|hagezi_samsung_mobile|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.xiaomi.txt|hagezi_xiaomi|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.huawei.txt|hagezi_huawei|tracking
 
 # ============================================================================
 # MALICIOUS & PHISHING BLOCKLISTS


### PR DESCRIPTION
## Critical: 8 configured hagezi feeds were silently dead

hagezi restructured `dns-blocklists` — the `hosts/` and `domains/` directories were removed and everything consolidated under `adblock/` (ABP format). Eight of our configured hagezi feeds were failing and **contributing zero to weekly builds**. Verified via `curl` (2026-08-18):

| Feed | Category | Old URL status | Fix |
|------|----------|----------------|-----|
| `hagezi_pro` | comprehensive | `hosts/pro.txt` → **403** (exceeds jsdelivr's 150 MB limit in hosts format) | → `adblock/pro.txt` (~4.8 MB, ABP) |
| `hagezi_roku` | tracking | `domains/native.roku.txt` → **404** | → `adblock/native.roku.txt` |
| `hagezi_lg` | tracking | `domains/native.lgwebos.txt` → **404** | → `adblock/native.lgwebos.txt` |
| `hagezi_windows` | tracking | `domains/native.winoffice.txt` → **404** | → `adblock/native.winoffice.txt` |
| `hagezi_apple` | tracking | `domains/native.apple.txt` → **404** | → `adblock/native.apple.txt` |
| `hagezi_samsung_mobile` | tracking | `domains/native.samsung.txt` → **404** | → `adblock/native.samsung.txt` |
| `hagezi_xiaomi` | tracking | `domains/native.xiaomi.txt` → **404** | → `adblock/native.xiaomi.txt` |
| `hagezi_huawei` | tracking | `domains/native.huawei.txt` → **404** | → `adblock/native.huawei.txt` |

`hagezi_pro` is our **#1 comprehensive aggregate** — its loss meaningfully degraded coverage.

## Behaviour-preserving

The optimizer already flattens ABP (`||domain^`) input to exact `0.0.0.0` entries for non-`abp` sources (exactly as it does for the existing `adblock/tif.txt`, `fake.txt`, etc. — e.g. a `tif.txt` `||domain^` entry lands in `malicious.txt` as an exact host). So this swap preserves current behaviour: exact-apex blocking, no subdomain expansion, no change to the false-positive profile.

All 12 hagezi URLs now return **HTTP 200**. Takes effect on the next weekly rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)