### PR TITLE
feat(sources): add 9 researched blocklist sources

### DIFF
--- a/blocklists.conf
+++ b/blocklists.conf
@@ -1,11 +1,12 @@
 # Zach's Lists - Default Block List
-# Last Updated: 18/08/26 - Fixed 8 dead hagezi feed URLs (repo moved hosts/ + domains/ → adblock/)
+# Last Updated: 25/08/26 - Added 9 researched sources (AdGuard DNS, ShadowWhisperer scam+malware, 4 hagezi native, 1Hosts Lite, StevenBlack porn)
 
 # ============================================================================
 # COMPREHENSIVE BLOCKLISTS
 # ============================================================================
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/pro.txt|hagezi_pro|comprehensive
 https://big.oisd.nl|oisd_big|comprehensive
+https://raw.githubusercontent.com/badmojr/1Hosts/master/Lite/domains.txt|badmojr_1hosts_lite|comprehensive
 
 # ============================================================================
 # THREAT INTELLIGENCE
@@ -26,6 +27,7 @@ https://adaway.org/hosts.txt|adaway|advertising
 https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimetype=plaintext|pgl_yoyo|advertising
 https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt|anudeep_adservers|advertising
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/popupads.txt|hagezi_popupads|advertising
+https://cdn.jsdelivr.net/gh/AdguardTeam/AdGuardSDNSFilter@gh-pages/Filters/filter.txt|adguard_dns|advertising
 
 # ============================================================================
 # TRACKING & TELEMETRY BLOCKLISTS
@@ -38,6 +40,10 @@ https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.apple.tx
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.samsung.txt|hagezi_samsung_mobile|tracking
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.xiaomi.txt|hagezi_xiaomi|tracking
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.huawei.txt|hagezi_huawei|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.oppo-realme.txt|hagezi_oppo_realme|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.vivo.txt|hagezi_vivo|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.tiktok.txt|hagezi_tiktok|tracking
+https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/native.amazon.txt|hagezi_amazon|tracking
 
 # ============================================================================
 # MALICIOUS & PHISHING BLOCKLISTS
@@ -50,6 +56,8 @@ https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20vers
 https://malware-filter.gitlab.io/malware-filter/phishing-filter-hosts.txt|curbengh_phishing|malicious
 https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt|spam404|malicious
 https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/dyndns.txt|hagezi_dyndns|malicious
+https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Scam|shadowwhisperer_scam|malicious
+https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Malware|shadowwhisperer_malware|malicious
 
 # ============================================================================
 # SUSPICIOUS BLOCKLISTS
@@ -70,3 +78,4 @@ https://raw.githubusercontent.com/zachlagden/Pi-hole-Optimized-Blocklists/main/c
 # NSFW BLOCKLISTS
 # ============================================================================
 https://nsfw.oisd.nl|oisd_nsfw|nsfw
+https://raw.githubusercontent.com/StevenBlack/hosts/master/alternates/porn-only/hosts|stevenblack_porn|nsfw


### PR DESCRIPTION
## What

Adds **9 new sources** to `blocklists.conf` (34 → 43 active), selected from a multi-source research pass and independently curl-verified (HTTP 200, format, active maintenance) and **FP-probed against legitimate domains**.

| Source | Category | Notes |
|--------|----------|-------|
| `badmojr_1hosts_lite` | comprehensive | 1Hosts **Lite** tier, independent of hagezi (diversifies source mix), daily, low-FP tier |
| `adguard_dns` | advertising | AdGuard DNS filter — distinct EasyList lineage, ~96k domains beyond hagezi_pro/oisd_big, DNS-purpose-built |
| `hagezi_oppo_realme` | tracking | hagezi native phone-vendor telemetry |
| `hagezi_vivo` | tracking | hagezi native phone-vendor telemetry |
| `hagezi_tiktok` | tracking | hagezi native app telemetry (hard to cover elsewhere) |
| `hagezi_amazon` | tracking | hagezi native device/service telemetry |
| `shadowwhisperer_scam` | malicious | **Low-FP replacement for the removed jarelllama feed** — hand-curated, no NRD/heuristic blocking |
| `shadowwhisperer_malware` | malicious | Companion malware feed, same maintainer |
| `stevenblack_porn` | nsfw | porn-only extension, independent of oisd_nsfw |

## FP verification (why these, and one rejection)

- `shadowwhisperer_scam` / `_malware` → **0 hits** on ebay/etsy/shopify/paypal/amazon/gofundme/wise/revolut/google/microsoft/github/cloudflare — and clean on `rei.com` + `commbank.com.au`, the exact legit shops jarelllama wrongly blocked. No NRD blocking (the failure mode that got jarelllama removed).
- `badmojr_1hosts_lite` → clean on all legit-brand + former-jarelllama-victim probes.
- **StevenBlack unified — rejected**: it blocks `www.occoquananimalhospital.com` (a vet clinic, imported via `someonewhocares`), which fails our false-positive bar. The **porn-only** extension (different aggregate) is used instead for NSFW.

All entries are hosts/plain/ABP format (optimizer-compatible); no `|abp` flag needed (ABP input is flattened to exact entries for non-`abp` sources, behaviour-consistent with our existing `adblock/*` feeds).

Takes effect on the next weekly rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)