### PR TITLE
feat(blocklist): add infozaem.com to malicious list

### DIFF
--- a/custom/malicious.txt
+++ b/custom/malicious.txt
@@ -29,3 +29,10 @@ novugs.com
 ||halaalstyle.com^
 ||awadio.pl^
 ||lamanucure.de^
+# infozaem.com — Ukrainian loan-aggregator/classifieds site flagged malicious by 8/92 engines on
+# VirusTotal (verified live), incl. ESET (Malware), VIPRE (Malware), Webroot (Malicious) and
+# alphaMountain + SafeToOpen (Phishing) — likely serving injected/malvertising or redirect content
+# (VT tags: iframes, external-resources, trackers). Reporter-supplied VT evidence, independently
+# confirmed. Its same-operator sibling uacred.com was clean (0/91 VT) and is deliberately NOT blocked.
+# Apex + all subdomains (ABP). (#75, PR #77)
+||infozaem.com^


### PR DESCRIPTION
## What

Adds `||infozaem.com^` to `custom/malicious.txt`.

## Why

Reported in #75. On independent verification (live VirusTotal, re-scanned today), `https://infozaem.com/` is flagged by **8/92 engines**, including reputable ones:

- **ESET → Malware**, **VIPRE → Malware**, **Webroot → Malicious**
- **alphaMountain.ai → Phishing**, **SafeToOpen → Phishing**
- ADMINUSLabs / Chong Lua Dao / Lionic → Malicious; Gridinsoft → Suspicious

The VT resource tags (iframes, external-resources, trackers) suggest it's serving injected/malvertising or redirect content rather than its core loan copy. This is genuine multi-vendor corroboration from a reputable source — it clears our evidence bar for a malicious-category block.

**Its same-operator sibling `uacred.com` (#76) is deliberately NOT blocked** — it's clean on VirusTotal (0/91) and rated "very likely safe" by ScamAdviser. Shared ownership is not grounds to block a domain that carries no malice signal of its own.

Entered in ABP form to cover the apex and all subdomains. Takes effect on the next weekly rebuild.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)