### PR TITLE
fix(readme): PNG star history embed (renders through GitHub camo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Thanks to everyone who supports this project.
 
 <a href="https://github.com/zachlagden/Pi-hole-Optimized-Blocklists/stargazers">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://repo-star-history.zachlagden.uk/svg?repos=zachlagden/pi-hole-optimized-blocklists&type=Date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://repo-star-history.zachlagden.uk/svg?repos=zachlagden/pi-hole-optimized-blocklists&type=Date&legend=top-left" />
-   <img alt="Star History Chart for zachlagden/Pi-hole-Optimized-Blocklists" src="https://repo-star-history.zachlagden.uk/svg?repos=zachlagden/pi-hole-optimized-blocklists&type=Date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://repo-star-history.zachlagden.uk/svg?repos=zachlagden/pi-hole-optimized-blocklists&type=Date&theme=dark&legend=top-left&format=png" />
+   <source media="(prefers-color-scheme: light)" srcset="https://repo-star-history.zachlagden.uk/svg?repos=zachlagden/pi-hole-optimized-blocklists&type=Date&legend=top-left&format=png" />
+   <img alt="Star History Chart for zachlagden/Pi-hole-Optimized-Blocklists" src="https://repo-star-history.zachlagden.uk/svg?repos=zachlagden/pi-hole-optimized-blocklists&type=Date&legend=top-left&format=png" />
  </picture>
 </a>
 


### PR DESCRIPTION
The SVG embed rendered blank on GitHub — camo proxies README images under a CSP that (with the chart's hand-drawn filter) blanks the SVG in `<img>` context. Switched to the self-hosted service's PNG output (`?format=png`), which renders reliably. Charts still auto-update (24h cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)