### PR TITLE
Fix grammar in nsfw_abp.txt note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 | **[nsfw.txt](https://media.githubusercontent.com/media/zachlagden/Pi-hole-Optimized-Blocklists/main/lists/nsfw.txt)** | Adult content (separate) | 535,088 |
 | **[nsfw_abp.txt](https://media.githubusercontent.com/media/zachlagden/Pi-hole-Optimized-Blocklists/main/lists/nsfw_abp.txt)** | Adult content — ABP format, blocks subdomains too | 535,088 |
 
-> **Note:** `nsfw.txt` is **not** included in `all_domains.txt` because it blocks legitimate adult sites. Add it separately if you want NSFW blocking. `nsfw_abp.txt` is the same domains in ABP form (`||domain^`) so subdomains are blocked too — use it instead of `nsfw.txt` for more thorough filtering (needs Pi-hole Core ≥ 5.16).
+> **Note:** `nsfw.txt` is **not** included in `all_domains.txt` because it blocks legitimate adult sites. Add it separately if you want NSFW blocking. `nsfw_abp.txt` contains the same domains in ABP form (`||domain^`), so subdomains are blocked too — use it instead of `nsfw.txt` for more thorough filtering (needs Pi-hole Core ≥ 5.16).
 
 **Last updated**: August 30, 2026
 


### PR DESCRIPTION
## Summary
Fixes a grammar error in the `nsfw_abp.txt` note in the README.

## Changes
- Fixed subject-verb agreement: "is the same domains" -> "contains the same domains"

## Related Issues
N/A

No functional changes; README text only.